### PR TITLE
BUG: Use correct pinning template for run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - cfitsio_version.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win or osx]
   run_exports:
     # The ABI doesn't seem to change for minor or patch release,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
     # The ABI doesn't seem to change for minor or patch release,
     # https://abi-laboratory.pro/?view=timeline&l=cpl.
     # So we pin only major releases.
-    - {{ pin_compatible('cpl', max_pin='x') }}
+    - {{ pin_subpackage('cpl', max_pin='x') }}
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
